### PR TITLE
faker.js fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A command line application written in JavaScript, capable of populating a Postgr
 
 ### Node Dependencies
 
-- [faker.js](https://www.npmjs.com/package/faker) - Fake data generator to populate DB
+- [faker.js](https://www.npmjs.com/package/faker/v/5.5.3) - Fake data generator to populate DB. Uses version 5.5.3.
 - [@types/faker](https://www.npmjs.com/package/@types/faker) - Type definitions for [faker.js](https://www.npmjs.com/package/faker)
 - [node-postgres](https://www.npmjs.com/package/pg) - PostgreSQL client for Node.js
 - [node-pg-format](https://www.npmjs.com/package/pg-format) - Node.js implementation of PostgreSQL `format()`, for creating injection-proof SQL queries dynamically

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/willKip/BookstoreDBTerminal-F21-COMP3005#readme",
   "dependencies": {
-    "faker": "^5.5.3",
+    "faker": "5.5.3",
     "pg": "^8.7.1",
     "pg-format": "^1.0.4",
     "pgtools": "^0.3.2",


### PR DESCRIPTION
As of this commit, the faker.js library has been rendered useless by the creator. As a workaround, the project has been updated to use the last stable version, 5.5.3, that remains in npm. There should be no changes in the project due to this; the project was built when version 5.5.3 was the latest.